### PR TITLE
a custom parsing loop that stop consuming top-level input on error

### DIFF
--- a/parsing/parse.ml
+++ b/parsing/parse.ml
@@ -43,7 +43,7 @@ let wrap parsing_fun lexbuf =
   try
     Docstrings.init ();
     Lexer.init ();
-    let ast = parsing_fun token lexbuf in
+    let ast = parsing_fun lexbuf in
     Parsing.clear_parser();
     Docstrings.warn_bad_docstrings ();
     last_token := Parser.EOF;
@@ -63,18 +63,70 @@ let wrap parsing_fun lexbuf =
       then maybe_skip_phrase lexbuf;
       raise(Syntaxerr.Error(Syntaxerr.Other loc))
 
-let implementation = wrap Parser.implementation
-and interface = wrap Parser.interface
-and toplevel_phrase = wrap Parser.toplevel_phrase
-and use_file = wrap Parser.use_file
-and core_type = wrap Parser.parse_core_type
-and expression = wrap Parser.parse_expression
-and pattern = wrap Parser.parse_pattern
+let wrap_yacc parsing_fun =
+  wrap (fun lexbuf -> parsing_fun token lexbuf)
 
-let implementation_menhir = wrap Parser_menhir.implementation
-and interface_menhir = wrap Parser_menhir.interface
-and toplevel_phrase_menhir = wrap Parser_menhir.toplevel_phrase
-and use_file_menhir = wrap Parser_menhir.use_file
-and core_type_menhir = wrap Parser_menhir.parse_core_type
-and expression_menhir = wrap Parser_menhir.parse_expression
-and pattern_menhir = wrap Parser_menhir.parse_pattern
+let implementation = wrap_yacc Parser.implementation
+and interface = wrap_yacc Parser.interface
+and toplevel_phrase = wrap_yacc Parser.toplevel_phrase
+and use_file = wrap_yacc Parser.use_file
+and core_type = wrap_yacc Parser.parse_core_type
+and expression = wrap_yacc Parser.parse_expression
+and pattern = wrap_yacc Parser.parse_pattern
+
+let rec loop lexbuf in_error checkpoint =
+  let module I = Parser_menhir.MenhirInterpreter in
+  match checkpoint with
+  | I.InputNeeded _env ->
+      let triple =
+        if in_error then
+          (* The parser detected an error.
+             At this point we don't want to consume input anymore. In the
+             top-level, it would translate into waiting for the user to type
+             something, just to raise an error at some earlier position, rather
+             than just raising the error immediately.
+
+             This worked before with yacc because, AFAICT (@let-def):
+             - yacc eagerly reduces "default reduction" (when the next action
+               is to reduce the same production no matter what token is read,
+               yacc reduces it immediately rather than waiting for that token
+               to be read)
+             - error productions in OCaml grammar are always in a position that
+               allows default reduction ("error" symbol is the last producer,
+               and the lookahead token will not be used to disambiguate between
+               two possible error rules)
+             This solution is fragile because it relies on an optimization
+             (default reduction), that changes the semantics of the parser the
+             way it is implemented in Yacc (an optimization that changes
+             semantics? hmmmm).
+
+             Rather than relying on implementation details of the parser, when
+             an error is detected in this loop we stop looking at the input and
+             fill the parser with EOF tokens.
+             The skip_phrase logic will resynchronize the input stream by
+             looking for the next ';;'.  *)
+          (Parser.EOF, lexbuf.Lexing.lex_curr_p, lexbuf.Lexing.lex_curr_p)
+        else
+          let token = token lexbuf in
+          (token, lexbuf.Lexing.lex_start_p, lexbuf.Lexing.lex_curr_p)
+      in
+      let checkpoint = I.offer checkpoint triple in
+      loop lexbuf in_error checkpoint
+  | I.Shifting _ | I.AboutToReduce _ ->
+      loop lexbuf in_error (I.resume checkpoint)
+  | I.Accepted v -> v
+  | I.Rejected -> raise Parser_menhir.Error
+  | I.HandlingError _ ->
+      loop lexbuf true (I.resume checkpoint)
+
+let wrap_menhir entry lexbuf =
+  let initial = entry lexbuf.Lexing.lex_curr_p in
+  wrap (fun lexbuf -> loop lexbuf false initial) lexbuf
+
+let implementation_menhir = wrap_menhir Parser_menhir.Incremental.implementation
+and interface_menhir = wrap_menhir Parser_menhir.Incremental.interface
+and toplevel_phrase_menhir = wrap_menhir Parser_menhir.Incremental.toplevel_phrase
+and use_file_menhir = wrap_menhir Parser_menhir.Incremental.use_file
+and core_type_menhir = wrap_menhir Parser_menhir.Incremental.parse_core_type
+and expression_menhir = wrap_menhir Parser_menhir.Incremental.parse_expression
+and pattern_menhir = wrap_menhir Parser_menhir.Incremental.parse_pattern

--- a/testsuite/tests/parse-errors/unclosed_simple_expr.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_simple_expr.compilers.reference
@@ -56,38 +56,46 @@ Line 2, characters 17-19:
   simple_expr.{3, 2;;
               ^    ^^
 Syntax error: '}' expected, the highlighted '{' might be unmatched
+Line 2, characters 0-1,
 Line 2, characters 10-12:
   { x = 3; y;;
-            ^^
-Error: Syntax error
+  ^         ^^
+Syntax error: '}' expected, the highlighted '{' might be unmatched
+Line 2, characters 5-6,
 Line 2, characters 16-18:
   List.{ x = 3; y ;;
-                  ^^
-Error: Syntax error
+       ^          ^^
+Syntax error: '}' expected, the highlighted '{' might be unmatched
+Line 2, characters 0-2,
 Line 2, characters 7-9:
   [| 3; 2;;
-         ^^
-Error: Syntax error
+  ^^     ^^
+Syntax error: '|]' expected, the highlighted '[|' might be unmatched
+Line 2, characters 5-7,
 Line 2, characters 11-13:
   List.[|3; 2;;
-             ^^
-Error: Syntax error
+       ^^    ^^
+Syntax error: '|]' expected, the highlighted '[|' might be unmatched
+Line 2, characters 0-1,
 Line 2, characters 5-7:
   [3; 2;;
-       ^^
-Error: Syntax error
+  ^    ^^
+Syntax error: ']' expected, the highlighted '[' might be unmatched
+Line 2, characters 5-6,
 Line 2, characters 10-12:
   List.[3; 2;;
-            ^^
-Error: Syntax error
+       ^    ^^
+Syntax error: ']' expected, the highlighted '[' might be unmatched
+Line 2, characters 0-2,
 Line 2, characters 13-15:
   {< x = 3; y; ;;
-               ^^
-Error: Syntax error
+  ^^           ^^
+Syntax error: '>}' expected, the highlighted '{<' might be unmatched
+Line 2, characters 5-7,
 Line 2, characters 17-19:
   List.{< x = 3; y ;;
-                   ^^
-Error: Syntax error
+       ^^          ^^
+Syntax error: '>}' expected, the highlighted '{<' might be unmatched
 Line 2, characters 0-1,
 Line 2, characters 20-22:
   (module struct end :;;

--- a/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
@@ -11,20 +11,23 @@ Line 4, characters 0-2:
   ....(.......
   ;;
 Syntax error: ')' expected, the highlighted '(' might be unmatched
+Line 6, characters 18-25:
+    | (module Foo : sig end
+                    ^^^^^^^
+Error: invalid package type: only module type identifier and 'with type' constraints are supported
+Line 6, characters 4-5,
 Line 7, characters 0-2:
+  ....{..........
   ;;
-  ^^
-Error: Syntax error: module-expr expected.
-Line 7, characters 0-2:
-  ;;
-  ^^
-Error: Syntax error
+Syntax error: '}' expected, the highlighted '{' might be unmatched
+Line 3, characters 4-5,
 Line 4, characters 0-2:
+  ....[......
   ;;
-  ^^
-Error: Syntax error
+Syntax error: ']' expected, the highlighted '[' might be unmatched
+Line 3, characters 4-6,
 Line 4, characters 0-2:
+  ....[|......
   ;;
-  ^^
-Error: Syntax error
+Syntax error: '|]' expected, the highlighted '[|' might be unmatched
 


### PR DESCRIPTION
This implements a custom parsing loop to improve the behavior of top-level recovery.

Quoting a comment from the code:

> The parser detected an error.
> At this point we don't want to consume input anymore.
> In the top-level it would translate into waiting for the user to type
> something just to raise an error at some earlier position rather
> than just raising the error immediately.
>
> This worked before with yacc because, AFAICT (@let-def):
> - yacc eagerly reduces "default reduction" (when the next action
>   is to reduce the same production no matter what token is read,
>   yacc reduces it immediately rather than waiting for that token
>   to be read)
> - error productions in OCaml grammar are always in a position that
>   allows default reduction ("error" symbol is the last producer,
>   and the lookahead token will not be used to disambiguate between
>   two possible error rules)
>
> This solution is fragile because it relies on an optimization
> (default reduction), that changes the semantics of the parser the
> way it is implemented in Yacc (an optimization that changes
> semantics? hmmmm).
>
> Rather than relying on implementation details of the parser, when
> an error is detected in this loop we stop looking at the input and
> fill the parser with EOF tokens.
> The skip_phrase logic will resynchronize the input stream by
> looking for the next ';;'.
