### PR TITLE
toplevel: find shorter path using the environment more directly

### DIFF
--- a/testsuite/tests/tool-toplevel/constructor_printing.ml
+++ b/testsuite/tests/tool-toplevel/constructor_printing.ml
@@ -1,0 +1,53 @@
+(* TEST
+ expect;
+*)
+
+module M = struct
+  module N = struct
+    type t = A | B | C
+  end
+end
+[%%expect {|
+module M : sig module N : sig type t = A | B | C end end
+|}]
+
+let it = (M.N.A, M.N.B, M.N.C)
+[%%expect {|
+val it : M.N.t * M.N.t * M.N.t = (M.N.A, M.N.B, M.N.C)
+|}]
+
+open M
+let it = (N.A, N.B, N.C)
+(* The behavior in this case is known to be suboptimal: #12642. *)
+[%%expect {|
+val it : M.N.t * M.N.t * M.N.t = (M.N.A, M.N.B, M.N.C)
+|}]
+
+open N
+
+let it = (A, B, C)
+[%%expect {|
+val it : M.N.t * M.N.t * M.N.t = (A, B, C)
+|}]
+
+
+module O = struct
+  module P = struct
+    type t = D | E | F
+  end
+end
+[%%expect {|
+module O : sig module P : sig type t = D | E | F end end
+|}]
+
+let it = (O.P.D, O.P.E, O.P.F)
+[%%expect {|
+val it : O.P.t * O.P.t * O.P.t = (O.P.D, O.P.E, O.P.F)
+|}]
+
+open O.P
+
+let it = (D, E, F)
+[%%expect {|
+val it : O.P.t * O.P.t * O.P.t = (D, E, F)
+|}]

--- a/testsuite/tests/tool-toplevel/constructor_printing.ml
+++ b/testsuite/tests/tool-toplevel/constructor_printing.ml
@@ -18,9 +18,8 @@ val it : M.N.t * M.N.t * M.N.t = (M.N.A, M.N.B, M.N.C)
 
 open M
 let it = (N.A, N.B, N.C)
-(* The behavior in this case is known to be suboptimal: #12642. *)
 [%%expect {|
-val it : M.N.t * M.N.t * M.N.t = (M.N.A, M.N.B, M.N.C)
+val it : M.N.t * M.N.t * M.N.t = (N.A, N.B, N.C)
 |}]
 
 open N

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -206,73 +206,22 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
        it comes from. Attempt to omit the prefix if the type comes from
        a module that has been opened. *)
 
-    let tree_of_qualified lookup_all get_path env ty_path name =
-      (* If [ty_path] is [M.N.t] and [name] is [Foo], we want to find
-         a short name for [M.N.Foo] in the current typing environment.
-         Our strategy is to try [Foo], [N.Foo] and [M.N.Foo] in
-         turn. *)
+    let rec tree_of_lident = function
+      | Lident name -> tree_of_name name
+      | Ldot (lid, name) -> Oide_dot (tree_of_lident lid, name)
+      | Lapply (lid1, lid2) ->
+          Oide_apply (tree_of_lident lid1, tree_of_lident lid2)
 
-      (* Start by transforming the path [M.N.t] into the Longident [M.N.Foo]. *)
-      let rec lid_of_path on_last =
-        let lid_non_last lid = lid_of_path Fun.id lid in
-        function
-        | Pident last -> Lident (on_last (Ident.name last))
-        | Pdot (p, last) -> Ldot (lid_non_last p, on_last last)
-        | Papply (f, p) -> Lapply (lid_non_last f, lid_non_last p)
-        | Pextra_ty (p, _) ->
-            (* These can only appear directly inside of the associated
-               constructor so we can just drop the prefix *)
-            lid_of_path on_last p
+    let tree_of_qualified relative_path env ty_path name =
+      let lid = match relative_path ty_path env with
+        | None -> Lident name
+        | Some lid -> Ldot(lid,name)
       in
-      let lid = lid_of_path (fun _tyname -> name) ty_path in
+      tree_of_lident lid
 
-      (* [candidates exn M.N.Foo] is [Foo; N.Foo; M.N.Foo].
-         @raise [exn] on functor application. *)
-      let candidates apply_exn lid =
-        (* [loop M.N [Foo]] is [[Foo]; [N; Foo]; [M; N; Foo]] *)
-        let rec loop lid suff = match lid with
-          | Lident last -> [suff; (last :: suff)]
-          | Ldot(p, s) -> suff :: loop p (s :: suff)
-          | Lapply _ -> raise apply_exn
-        in
-        loop lid [] (* [[]; [Foo]; [N; Foo]; [M; N; Foo]] *)
-        |> List.filter_map Longident.unflatten
-      in
+    let tree_of_constr = tree_of_qualified Env.relative_constructor_path
 
-      (* A shorter name is correct (matches) if one of its possible interpretations
-         (there may be several constructors with the same name at different types in a module)
-         has the same type path as the one we are printing. *)
-      let matches lid =
-        match lookup_all lid env with
-        | Error _ -> false
-        | Ok cstrs ->
-            List.exists (fun (cstr, _) ->
-              Path.same (get_path cstr) ty_path
-            ) cstrs
-      in
-
-      let rec tree_of_lident = function
-        | Lident name -> tree_of_name name
-        | Ldot (lid, name) -> Oide_dot (tree_of_lident lid, name)
-        | Lapply (lid1, lid2) -> Oide_apply (tree_of_lident lid1, tree_of_lident lid2)
-      in
-
-      let exception Functor_application in
-      match List.find matches (candidates Functor_application lid) with
-      | exception (Functor_application | Not_found) ->
-          tree_of_lident lid
-      | best_lid ->
-          tree_of_lident best_lid
-
-    let tree_of_constr =
-      tree_of_qualified
-        (Env.lookup_all_constructors ~use:false ~loc:Location.none Env.Positive)
-        Data_types.cstr_res_type_path
-
-    and tree_of_label =
-      tree_of_qualified
-        (Env.lookup_all_labels ~use:false ~loc:Location.none Env.Construct)
-        Data_types.lbl_res_type_path
+    let tree_of_label = tree_of_qualified Env.relative_label_path
 
     (* An abstract type *)
 

--- a/typing/data_types.ml
+++ b/typing/data_types.ml
@@ -71,8 +71,8 @@ let cstr_res_type_path cstr =
 
 type label_description =
   { lbl_name: string;                   (* Short name *)
-    lbl_res: type_expr;                 (* Type of the result *)
-    lbl_arg: type_expr;                 (* Type of the argument *)
+    lbl_res: type_expr;                 (* Type of the result (the record) *)
+    lbl_arg: type_expr;                 (* Type of the argument (the field value) *)
     lbl_mut: mutable_flag;              (* Is this a mutable field? *)
     lbl_pos: int;                       (* Position in block *)
     lbl_all: label_description array;   (* All the labels in this type *)
@@ -82,3 +82,8 @@ type label_description =
     lbl_attributes: Parsetree.attributes;
     lbl_uid: Uid.t;
    }
+
+let lbl_res_type_path lbl =
+  match get_desc lbl.lbl_res with
+  | Tconstr (p, _, _) -> p
+  | _ -> assert false

--- a/typing/data_types.mli
+++ b/typing/data_types.mli
@@ -57,8 +57,8 @@ val cstr_res_type_path : constructor_description -> Path.t
 
 type label_description =
   { lbl_name: string;                   (* Short name *)
-    lbl_res: type_expr;                 (* Type of the result *)
-    lbl_arg: type_expr;                 (* Type of the argument *)
+    lbl_res: type_expr;                 (* Type of the result (the record) *)
+    lbl_arg: type_expr;                 (* Type of the argument (the field value) *)
     lbl_mut: mutable_flag;              (* Is this a mutable field? *)
     lbl_pos: int;                       (* Position in block *)
     lbl_all: label_description array;   (* All the labels in this type *)
@@ -68,3 +68,6 @@ type label_description =
     lbl_attributes: Parsetree.attributes;
     lbl_uid: Uid.t;
   }
+
+(* Type constructor of the label record type. *)
+val lbl_res_type_path : label_description -> Path.t

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -115,6 +115,9 @@ val find_constructor_address: Path.t -> t -> address
 val shape_of_path:
   namespace:Shape.Sig_component_kind.t -> t -> Path.t -> Shape.t
 
+val relative_constructor_path: Path.t -> t -> Longident.t option
+val relative_label_path: Path.t -> t -> Longident.t option
+
 val add_functor_arg: Ident.t -> t -> t
 val is_functor_arg: Path.t -> t -> bool
 

--- a/typing/path.mli
+++ b/typing/path.mli
@@ -76,5 +76,9 @@ val last: t -> string
 
 val is_constructor_typath: t -> bool
 
+val longident: t -> Longident.t
+val is_prefix: t -> t -> bool
+val split_path: prefix:t -> t -> Longident.t option
+
 module Map : Map.S with type key = t
 module Set : Set.S with type elt = t

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -92,14 +92,7 @@ let string_is_prefix sub str =
   let sublen = String.length sub in
   String.length str >= sublen && String.sub str 0 sublen = sub
 
-let rec lident_of_path = function
-  | Path.Pident id -> Longident.Lident (Ident.name id)
-  | Path.Papply (p1, p2) ->
-      Longident.Lapply (lident_of_path p1, lident_of_path p2)
-  | Path.Pdot (p, s) | Path.Pextra_ty (p, Pcstr_ty s) ->
-      Longident.Ldot (lident_of_path p, s)
-  | Path.Pextra_ty (p, _) -> lident_of_path p
-
+let lident_of_path = Path.longident
 let map_loc sub {loc; txt} = {loc = sub.location sub loc; txt}
 
 (** Extract the [n] patterns from the case of a letop *)


### PR DESCRIPTION
ping @gasche

This sub-PR implements my proposition for using the data available in `Env` to find shorter path for constructor, rather than doing multiple requests to the environment on successively longer guesses.